### PR TITLE
feat: add core entities (Player, RiotAccount, PlayerStats, PlayedCham…

### DIFF
--- a/migrations/Version20260422153212.php
+++ b/migrations/Version20260422153212.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260422153212 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE club (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(150) NOT NULL, description LONGTEXT DEFAULT NULL, logo_url VARCHAR(255) DEFAULT NULL, website VARCHAR(255) DEFAULT NULL, is_verified TINYINT NOT NULL, user_id INT NOT NULL, UNIQUE INDEX UNIQ_B8EE3872A76ED395 (user_id), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci`');
+        $this->addSql('CREATE TABLE offer (id INT AUTO_INCREMENT NOT NULL, title VARCHAR(150) NOT NULL, description LONGTEXT NOT NULL, wanted_role VARCHAR(255) NOT NULL, minimum_rank VARCHAR(50) NOT NULL, published_at DATETIME NOT NULL, expires_at DATE DEFAULT NULL, is_active TINYINT NOT NULL, club_id INT NOT NULL, INDEX IDX_29D6873E61190A32 (club_id), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci`');
+        $this->addSql('CREATE TABLE played_champion (id INT AUTO_INCREMENT NOT NULL, champion_name VARCHAR(50) NOT NULL, games_played INT NOT NULL, winrate NUMERIC(5, 2) NOT NULL, kda NUMERIC(4, 2) NOT NULL, player_stats_id INT NOT NULL, INDEX IDX_6924CEFB767D7562 (player_stats_id), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci`');
+        $this->addSql('CREATE TABLE player (id INT AUTO_INCREMENT NOT NULL, pseudo VARCHAR(100) NOT NULL, first_name VARCHAR(100) NOT NULL, last_name VARCHAR(100) NOT NULL, game_role VARCHAR(255) NOT NULL, is_available TINYINT NOT NULL, bio LONGTEXT DEFAULT NULL, user_id INT NOT NULL, UNIQUE INDEX UNIQ_98197A65A76ED395 (user_id), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci`');
+        $this->addSql('CREATE TABLE player_stats (id INT AUTO_INCREMENT NOT NULL, tier VARCHAR(50) NOT NULL, winrate NUMERIC(5, 2) NOT NULL, average_kda NUMERIC(4, 2) NOT NULL, cs_per_minute NUMERIC(4, 2) NOT NULL, vision_score NUMERIC(5, 2) NOT NULL, ranked_games_count INT NOT NULL, riot_account_id INT NOT NULL, UNIQUE INDEX UNIQ_E8351CECC6EAB37D (riot_account_id), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci`');
+        $this->addSql('CREATE TABLE riot_account (id INT AUTO_INCREMENT NOT NULL, summoner_name VARCHAR(100) NOT NULL, puuid VARCHAR(78) NOT NULL, region VARCHAR(10) NOT NULL, last_sync_at DATETIME DEFAULT NULL, player_id INT NOT NULL, UNIQUE INDEX UNIQ_79C2D42DCFCB9868 (puuid), INDEX IDX_79C2D42D99E6F5DF (player_id), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci`');
+        $this->addSql('ALTER TABLE club ADD CONSTRAINT FK_B8EE3872A76ED395 FOREIGN KEY (user_id) REFERENCES `user` (id)');
+        $this->addSql('ALTER TABLE offer ADD CONSTRAINT FK_29D6873E61190A32 FOREIGN KEY (club_id) REFERENCES club (id)');
+        $this->addSql('ALTER TABLE played_champion ADD CONSTRAINT FK_6924CEFB767D7562 FOREIGN KEY (player_stats_id) REFERENCES player_stats (id)');
+        $this->addSql('ALTER TABLE player ADD CONSTRAINT FK_98197A65A76ED395 FOREIGN KEY (user_id) REFERENCES `user` (id)');
+        $this->addSql('ALTER TABLE player_stats ADD CONSTRAINT FK_E8351CECC6EAB37D FOREIGN KEY (riot_account_id) REFERENCES riot_account (id)');
+        $this->addSql('ALTER TABLE riot_account ADD CONSTRAINT FK_79C2D42D99E6F5DF FOREIGN KEY (player_id) REFERENCES player (id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE club DROP FOREIGN KEY FK_B8EE3872A76ED395');
+        $this->addSql('ALTER TABLE offer DROP FOREIGN KEY FK_29D6873E61190A32');
+        $this->addSql('ALTER TABLE played_champion DROP FOREIGN KEY FK_6924CEFB767D7562');
+        $this->addSql('ALTER TABLE player DROP FOREIGN KEY FK_98197A65A76ED395');
+        $this->addSql('ALTER TABLE player_stats DROP FOREIGN KEY FK_E8351CECC6EAB37D');
+        $this->addSql('ALTER TABLE riot_account DROP FOREIGN KEY FK_79C2D42D99E6F5DF');
+        $this->addSql('DROP TABLE club');
+        $this->addSql('DROP TABLE offer');
+        $this->addSql('DROP TABLE played_champion');
+        $this->addSql('DROP TABLE player');
+        $this->addSql('DROP TABLE player_stats');
+        $this->addSql('DROP TABLE riot_account');
+    }
+}

--- a/src/Entity/Club.php
+++ b/src/Entity/Club.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\ClubRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: ClubRepository::class)]
+class Club
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 150)]
+    private ?string $name = null;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $description = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $logoUrl = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $website = null;
+
+    #[ORM\Column]
+    private bool $isVerified = false;
+
+    #[ORM\OneToOne]
+    #[ORM\JoinColumn(nullable: false, unique: true)]
+    private ?User $user = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): static
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(?string $description): static
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function getLogoUrl(): ?string
+    {
+        return $this->logoUrl;
+    }
+
+    public function setLogoUrl(?string $logoUrl): static
+    {
+        $this->logoUrl = $logoUrl;
+
+        return $this;
+    }
+
+    public function getWebsite(): ?string
+    {
+        return $this->website;
+    }
+
+    public function setWebsite(?string $website): static
+    {
+        $this->website = $website;
+
+        return $this;
+    }
+
+    public function isVerified(): bool
+    {
+        return $this->isVerified;
+    }
+
+    public function setIsVerified(bool $isVerified): static
+    {
+        $this->isVerified = $isVerified;
+
+        return $this;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(User $user): static
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+}

--- a/src/Entity/Offer.php
+++ b/src/Entity/Offer.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Enum\PlayerRole;
+use App\Repository\OfferRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: OfferRepository::class)]
+class Offer
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 150)]
+    private ?string $title = null;
+
+    #[ORM\Column(type: 'text')]
+    private ?string $description = null;
+
+    #[ORM\Column(enumType: PlayerRole::class)]
+    private ?PlayerRole $wantedRole = null;
+
+    #[ORM\Column(length: 50)]
+    private ?string $minimumRank = null;
+
+    #[ORM\Column]
+    private \DateTimeImmutable $publishedAt;
+
+    #[ORM\Column(type: 'date_immutable', nullable: true)]
+    private ?\DateTimeImmutable $expiresAt = null;
+
+    #[ORM\Column]
+    private bool $isActive = true;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Club $club = null;
+
+    public function __construct()
+    {
+        $this->publishedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): static
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): static
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function getWantedRole(): ?PlayerRole
+    {
+        return $this->wantedRole;
+    }
+
+    public function setWantedRole(PlayerRole $wantedRole): static
+    {
+        $this->wantedRole = $wantedRole;
+
+        return $this;
+    }
+
+    public function getMinimumRank(): ?string
+    {
+        return $this->minimumRank;
+    }
+
+    public function setMinimumRank(string $minimumRank): static
+    {
+        $this->minimumRank = $minimumRank;
+
+        return $this;
+    }
+
+    public function getPublishedAt(): \DateTimeImmutable
+    {
+        return $this->publishedAt;
+    }
+
+    public function setPublishedAt(\DateTimeImmutable $publishedAt): static
+    {
+        $this->publishedAt = $publishedAt;
+
+        return $this;
+    }
+
+    public function getExpiresAt(): ?\DateTimeImmutable
+    {
+        return $this->expiresAt;
+    }
+
+    public function setExpiresAt(?\DateTimeImmutable $expiresAt): static
+    {
+        $this->expiresAt = $expiresAt;
+
+        return $this;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->isActive;
+    }
+
+    public function setIsActive(bool $isActive): static
+    {
+        $this->isActive = $isActive;
+
+        return $this;
+    }
+
+    public function getClub(): ?Club
+    {
+        return $this->club;
+    }
+
+    public function setClub(Club $club): static
+    {
+        $this->club = $club;
+
+        return $this;
+    }
+}

--- a/src/Entity/PlayedChampion.php
+++ b/src/Entity/PlayedChampion.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\PlayedChampionRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: PlayedChampionRepository::class)]
+class PlayedChampion
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 50)]
+    private ?string $championName = null;
+
+    #[ORM\Column]
+    private ?int $gamesPlayed = null;
+
+    #[ORM\Column(type: 'decimal', precision: 5, scale: 2)]
+    private ?string $winrate = null;
+
+    #[ORM\Column(type: 'decimal', precision: 4, scale: 2)]
+    private ?string $kda = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?PlayerStats $playerStats = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getChampionName(): ?string
+    {
+        return $this->championName;
+    }
+
+    public function setChampionName(string $championName): static
+    {
+        $this->championName = $championName;
+
+        return $this;
+    }
+
+    public function getGamesPlayed(): ?int
+    {
+        return $this->gamesPlayed;
+    }
+
+    public function setGamesPlayed(int $gamesPlayed): static
+    {
+        $this->gamesPlayed = $gamesPlayed;
+
+        return $this;
+    }
+
+    public function getWinrate(): ?string
+    {
+        return $this->winrate;
+    }
+
+    public function setWinrate(string $winrate): static
+    {
+        $this->winrate = $winrate;
+
+        return $this;
+    }
+
+    public function getKda(): ?string
+    {
+        return $this->kda;
+    }
+
+    public function setKda(string $kda): static
+    {
+        $this->kda = $kda;
+
+        return $this;
+    }
+
+    public function getPlayerStats(): ?PlayerStats
+    {
+        return $this->playerStats;
+    }
+
+    public function setPlayerStats(PlayerStats $playerStats): static
+    {
+        $this->playerStats = $playerStats;
+
+        return $this;
+    }
+}

--- a/src/Entity/Player.php
+++ b/src/Entity/Player.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Enum\PlayerRole;
+use App\Repository\PlayerRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: PlayerRepository::class)]
+class Player
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 100)]
+    private ?string $pseudo = null;
+
+    #[ORM\Column(length: 100)]
+    private ?string $firstName = null;
+
+    #[ORM\Column(length: 100)]
+    private ?string $lastName = null;
+
+    #[ORM\Column(enumType: PlayerRole::class)]
+    private ?PlayerRole $gameRole = null;
+
+    #[ORM\Column]
+    private bool $isAvailable = true;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $bio = null;
+
+    #[ORM\OneToOne]
+    #[ORM\JoinColumn(nullable: false, unique: true)]
+    private ?User $user = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getPseudo(): ?string
+    {
+        return $this->pseudo;
+    }
+
+    public function setPseudo(string $pseudo): static
+    {
+        $this->pseudo = $pseudo;
+
+        return $this;
+    }
+
+    public function getFirstName(): ?string
+    {
+        return $this->firstName;
+    }
+
+    public function setFirstName(string $firstName): static
+    {
+        $this->firstName = $firstName;
+
+        return $this;
+    }
+
+    public function getLastName(): ?string
+    {
+        return $this->lastName;
+    }
+
+    public function setLastName(string $lastName): static
+    {
+        $this->lastName = $lastName;
+
+        return $this;
+    }
+
+    public function getGameRole(): ?PlayerRole
+    {
+        return $this->gameRole;
+    }
+
+    public function setGameRole(PlayerRole $gameRole): static
+    {
+        $this->gameRole = $gameRole;
+
+        return $this;
+    }
+
+    public function isAvailable(): bool
+    {
+        return $this->isAvailable;
+    }
+
+    public function setIsAvailable(bool $isAvailable): static
+    {
+        $this->isAvailable = $isAvailable;
+
+        return $this;
+    }
+
+    public function getBio(): ?string
+    {
+        return $this->bio;
+    }
+
+    public function setBio(?string $bio): static
+    {
+        $this->bio = $bio;
+
+        return $this;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(User $user): static
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+}

--- a/src/Entity/PlayerStats.php
+++ b/src/Entity/PlayerStats.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\PlayerStatsRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: PlayerStatsRepository::class)]
+class PlayerStats
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 50)]
+    private ?string $tier = null;
+
+    #[ORM\Column(type: 'decimal', precision: 5, scale: 2)]
+    private ?string $winrate = null;
+
+    #[ORM\Column(type: 'decimal', precision: 4, scale: 2)]
+    private ?string $averageKda = null;
+
+    #[ORM\Column(type: 'decimal', precision: 4, scale: 2)]
+    private ?string $csPerMinute = null;
+
+    #[ORM\Column(type: 'decimal', precision: 5, scale: 2)]
+    private ?string $visionScore = null;
+
+    #[ORM\Column]
+    private ?int $rankedGamesCount = null;
+
+    #[ORM\OneToOne]
+    #[ORM\JoinColumn(nullable: false, unique: true)]
+    private ?RiotAccount $riotAccount = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getTier(): ?string
+    {
+        return $this->tier;
+    }
+
+    public function setTier(string $tier): static
+    {
+        $this->tier = $tier;
+
+        return $this;
+    }
+
+    public function getWinrate(): ?string
+    {
+        return $this->winrate;
+    }
+
+    public function setWinrate(string $winrate): static
+    {
+        $this->winrate = $winrate;
+
+        return $this;
+    }
+
+    public function getAverageKda(): ?string
+    {
+        return $this->averageKda;
+    }
+
+    public function setAverageKda(string $averageKda): static
+    {
+        $this->averageKda = $averageKda;
+
+        return $this;
+    }
+
+    public function getCsPerMinute(): ?string
+    {
+        return $this->csPerMinute;
+    }
+
+    public function setCsPerMinute(string $csPerMinute): static
+    {
+        $this->csPerMinute = $csPerMinute;
+
+        return $this;
+    }
+
+    public function getVisionScore(): ?string
+    {
+        return $this->visionScore;
+    }
+
+    public function setVisionScore(string $visionScore): static
+    {
+        $this->visionScore = $visionScore;
+
+        return $this;
+    }
+
+    public function getRankedGamesCount(): ?int
+    {
+        return $this->rankedGamesCount;
+    }
+
+    public function setRankedGamesCount(int $rankedGamesCount): static
+    {
+        $this->rankedGamesCount = $rankedGamesCount;
+
+        return $this;
+    }
+
+    public function getRiotAccount(): ?RiotAccount
+    {
+        return $this->riotAccount;
+    }
+
+    public function setRiotAccount(RiotAccount $riotAccount): static
+    {
+        $this->riotAccount = $riotAccount;
+
+        return $this;
+    }
+}

--- a/src/Entity/RiotAccount.php
+++ b/src/Entity/RiotAccount.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\RiotAccountRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: RiotAccountRepository::class)]
+class RiotAccount
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 100)]
+    private ?string $summonerName = null;
+
+    #[ORM\Column(length: 78, unique: true)]
+    private ?string $puuid = null;
+
+    #[ORM\Column(length: 10)]
+    private ?string $region = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?\DateTimeImmutable $lastSyncAt = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Player $player = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getSummonerName(): ?string
+    {
+        return $this->summonerName;
+    }
+
+    public function setSummonerName(string $summonerName): static
+    {
+        $this->summonerName = $summonerName;
+
+        return $this;
+    }
+
+    public function getPuuid(): ?string
+    {
+        return $this->puuid;
+    }
+
+    public function setPuuid(string $puuid): static
+    {
+        $this->puuid = $puuid;
+
+        return $this;
+    }
+
+    public function getRegion(): ?string
+    {
+        return $this->region;
+    }
+
+    public function setRegion(string $region): static
+    {
+        $this->region = $region;
+
+        return $this;
+    }
+
+    public function getLastSyncAt(): ?\DateTimeImmutable
+    {
+        return $this->lastSyncAt;
+    }
+
+    public function setLastSyncAt(?\DateTimeImmutable $lastSyncAt): static
+    {
+        $this->lastSyncAt = $lastSyncAt;
+
+        return $this;
+    }
+
+    public function getPlayer(): ?Player
+    {
+        return $this->player;
+    }
+
+    public function setPlayer(Player $player): static
+    {
+        $this->player = $player;
+
+        return $this;
+    }
+}

--- a/src/Enum/PlayerRole.php
+++ b/src/Enum/PlayerRole.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+enum PlayerRole: string
+{
+    case TOP = 'TOP';
+    case JUNGLE = 'JUNGLE';
+    case MID = 'MID';
+    case ADC = 'ADC';
+    case SUPPORT = 'SUPPORT';
+}

--- a/src/Repository/ClubRepository.php
+++ b/src/Repository/ClubRepository.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\Club;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Club>
+ */
+class ClubRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Club::class);
+    }
+}

--- a/src/Repository/OfferRepository.php
+++ b/src/Repository/OfferRepository.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\Offer;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Offer>
+ */
+class OfferRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Offer::class);
+    }
+}

--- a/src/Repository/PlayedChampionRepository.php
+++ b/src/Repository/PlayedChampionRepository.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\PlayedChampion;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<PlayedChampion>
+ */
+class PlayedChampionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, PlayedChampion::class);
+    }
+}

--- a/src/Repository/PlayerRepository.php
+++ b/src/Repository/PlayerRepository.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\Player;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Player>
+ */
+class PlayerRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Player::class);
+    }
+}

--- a/src/Repository/PlayerStatsRepository.php
+++ b/src/Repository/PlayerStatsRepository.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\PlayerStats;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<PlayerStats>
+ */
+class PlayerStatsRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, PlayerStats::class);
+    }
+}

--- a/src/Repository/RiotAccountRepository.php
+++ b/src/Repository/RiotAccountRepository.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\RiotAccount;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<RiotAccount>
+ */
+class RiotAccountRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, RiotAccount::class);
+    }
+}


### PR DESCRIPTION
…pion, Club, Offer)

Add 6 entities covering the MVP scope from the J3 MLD:
- Player (1-to-1 with User) — pseudo, firstName, lastName, gameRole, isAvailable, bio
- RiotAccount (N-to-1 with Player) — summonerName, puuid, region, lastSyncAt
- PlayerStats (1-to-1 with RiotAccount) — tier, winrate, averageKda, csPerMinute, visionScore, rankedGamesCount
- PlayedChampion (N-to-1 with PlayerStats) — championName, gamesPlayed, winrate, kda
- Club (1-to-1 with User) — name, description, logoUrl, website, isVerified
- Offer (N-to-1 with Club) — title, description, wantedRole, minimumRank, publishedAt, expiresAt, isActive

New enum PlayerRole (TOP, JUNGLE, MID, ADC, SUPPORT) used by Player and Offer. All unidirectional relations for simplicity; inverse access via repositories. Notes for J4 deliverable:
- Entity names translated to English (Symfony convention) — mapping to French MLD names documented separately.
- 'rank' renamed to 'tier' to avoid MySQL 8 reserved keyword conflict (also semantically more accurate for LoL).