### PR TITLE
feat: add REST API controllers for Player, Club, Offer + CORS + valid…

### DIFF
--- a/.env
+++ b/.env
@@ -34,3 +34,7 @@ JWT_SECRET_KEY=%kernel.project_dir%/config/jwt/private.pem
 JWT_PUBLIC_KEY=%kernel.project_dir%/config/jwt/public.pem
 JWT_PASSPHRASE=!ChangeMeInProduction!
 ###< lexik/jwt-authentication-bundle ###
+
+###> nelmio/cors-bundle ###
+CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
+###< nelmio/cors-bundle ###

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,15 @@
         "doctrine/doctrine-migrations-bundle": "^3.7",
         "doctrine/orm": "^3.6",
         "lexik/jwt-authentication-bundle": "^3.2",
+        "nelmio/cors-bundle": "^2.6",
         "symfony/console": "7.2.*",
         "symfony/dotenv": "7.2.*",
         "symfony/flex": "^2.10",
         "symfony/framework-bundle": "7.2.*",
         "symfony/runtime": "7.2.*",
         "symfony/security-bundle": "7.2.*",
+        "symfony/serializer": "7.2.*",
+        "symfony/validator": "7.2.*",
         "symfony/yaml": "7.2.*"
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4964f29b6d56d439007a764256526cac",
+    "content-hash": "d42522324c168bc20d9d1d33e631a00b",
     "packages": [
         {
             "name": "doctrine/collections",
@@ -1307,6 +1307,71 @@
                 }
             ],
             "time": "2025-12-20T17:47:00+00:00"
+        },
+        {
+            "name": "nelmio/cors-bundle",
+            "version": "2.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nelmio/NelmioCorsBundle.git",
+                "reference": "3d80dbcd5d1eb5f8b20ed5199e1778d44c2e4d1c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nelmio/NelmioCorsBundle/zipball/3d80dbcd5d1eb5f8b20ed5199e1778d44c2e4d1c",
+                "reference": "3d80dbcd5d1eb5f8b20ed5199e1778d44c2e4d1c",
+                "shasum": ""
+            },
+            "require": {
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11.5",
+                "phpstan/phpstan-deprecation-rules": "^1.2.0",
+                "phpstan/phpstan-phpunit": "^1.4",
+                "phpstan/phpstan-symfony": "^1.4.4",
+                "phpunit/phpunit": "^8"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Nelmio\\CorsBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nelmio",
+                    "homepage": "http://nelm.io"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://github.com/nelmio/NelmioCorsBundle/contributors"
+                }
+            ],
+            "description": "Adds CORS (Cross-Origin Resource Sharing) headers support in your Symfony application",
+            "keywords": [
+                "api",
+                "cors",
+                "crossdomain"
+            ],
+            "support": {
+                "issues": "https://github.com/nelmio/NelmioCorsBundle/issues",
+                "source": "https://github.com/nelmio/NelmioCorsBundle/tree/2.6.1"
+            },
+            "time": "2026-01-12T15:59:08+00:00"
         },
         {
             "name": "psr/cache",
@@ -4309,6 +4374,108 @@
             "time": "2025-07-10T08:29:33+00:00"
         },
         {
+            "name": "symfony/serializer",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/serializer.git",
+                "reference": "91b01d65b553a6687c7b13432da1c0f4af1bf875"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/91b01d65b553a6687c7b13432da1c0f4af1bf875",
+                "reference": "91b01d65b553a6687c7b13432da1c0f4af1bf875",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "<3.2.2",
+                "phpdocumentor/type-resolver": "<1.4.0",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/property-access": "<6.4",
+                "symfony/property-info": "<6.4",
+                "symfony/uid": "<6.4",
+                "symfony/validator": "<6.4",
+                "symfony/yaml": "<6.4"
+            },
+            "require-dev": {
+                "phpdocumentor/reflection-docblock": "^3.2|^4.0|^5.0",
+                "phpstan/phpdoc-parser": "^1.0|^2.0",
+                "seld/jsonlint": "^1.10",
+                "symfony/cache": "^6.4|^7.0",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/console": "^6.4|^7.0",
+                "symfony/dependency-injection": "^7.2",
+                "symfony/error-handler": "^6.4|^7.0",
+                "symfony/filesystem": "^6.4|^7.0",
+                "symfony/form": "^6.4|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
+                "symfony/mime": "^6.4|^7.0",
+                "symfony/property-access": "^6.4|^7.0",
+                "symfony/property-info": "^6.4|^7.0",
+                "symfony/translation-contracts": "^2.5|^3",
+                "symfony/type-info": "^7.1.8",
+                "symfony/uid": "^6.4|^7.0",
+                "symfony/validator": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0",
+                "symfony/var-exporter": "^6.4|^7.0",
+                "symfony/yaml": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Serializer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/serializer/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-26T12:59:07+00:00"
+        },
+        {
             "name": "symfony/service-contracts",
             "version": "v3.6.1",
             "source": {
@@ -4704,6 +4871,107 @@
                 }
             ],
             "time": "2025-06-27T15:23:16+00:00"
+        },
+        {
+            "name": "symfony/validator",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/validator.git",
+                "reference": "b5410782f69892acf828e0eec7943a2caca46ed6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/b5410782f69892acf828e0eec7943a2caca46ed6",
+                "reference": "b5410782f69892acf828e0eec7943a2caca46ed6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php83": "^1.27",
+                "symfony/translation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "doctrine/lexer": "<1.1",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/doctrine-bridge": "<7.0",
+                "symfony/expression-language": "<6.4",
+                "symfony/http-kernel": "<6.4",
+                "symfony/intl": "<6.4",
+                "symfony/property-info": "<6.4",
+                "symfony/translation": "<6.4.3|>=7.0,<7.0.3",
+                "symfony/yaml": "<6.4"
+            },
+            "require-dev": {
+                "egulias/email-validator": "^2.1.10|^3|^4",
+                "symfony/cache": "^6.4|^7.0",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/console": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/expression-language": "^6.4|^7.0",
+                "symfony/finder": "^6.4|^7.0",
+                "symfony/http-client": "^6.4|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/intl": "^6.4|^7.0",
+                "symfony/mime": "^6.4|^7.0",
+                "symfony/property-access": "^6.4|^7.0",
+                "symfony/property-info": "^6.4|^7.0",
+                "symfony/translation": "^6.4.3|^7.0.3",
+                "symfony/type-info": "^7.1.8",
+                "symfony/yaml": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Validator\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/",
+                    "/Resources/bin/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools to validate values",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/validator/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-29T19:57:35+00:00"
         },
         {
             "name": "symfony/var-dumper",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -7,4 +7,5 @@ return [
     Symfony\Bundle\MakerBundle\MakerBundle::class => ['dev' => true],
     Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
     Lexik\Bundle\JWTAuthenticationBundle\LexikJWTAuthenticationBundle::class => ['all' => true],
+    Nelmio\CorsBundle\NelmioCorsBundle::class => ['all' => true],
 ];

--- a/config/packages/nelmio_cors.yaml
+++ b/config/packages/nelmio_cors.yaml
@@ -1,0 +1,10 @@
+nelmio_cors:
+    defaults:
+        origin_regex: true
+        allow_origin: ['%env(CORS_ALLOW_ORIGIN)%']
+        allow_methods: ['GET', 'OPTIONS', 'POST', 'PUT', 'PATCH', 'DELETE']
+        allow_headers: ['Content-Type', 'Authorization']
+        expose_headers: ['Link']
+        max_age: 3600
+    paths:
+        '^/': null

--- a/config/packages/validator.yaml
+++ b/config/packages/validator.yaml
@@ -1,0 +1,11 @@
+framework:
+    validation:
+        # Enables validator auto-mapping support.
+        # For instance, basic validation constraints will be inferred from Doctrine's metadata.
+        #auto_mapping:
+        #    App\Entity\: []
+
+when@test:
+    framework:
+        validation:
+            not_compromised_password: false

--- a/src/Controller/ClubController.php
+++ b/src/Controller/ClubController.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\Club;
+use App\Entity\User;
+use App\Repository\ClubRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+#[Route('/api/clubs')]
+class ClubController extends AbstractController
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly ClubRepository $clubRepository,
+        private readonly SerializerInterface $serializer,
+        private readonly ValidatorInterface $validator,
+    ) {
+    }
+
+    #[Route('', name: 'api_club_list', methods: ['GET'])]
+    public function list(): JsonResponse
+    {
+        $clubs = $this->clubRepository->findAll();
+
+        return $this->json(
+            $clubs,
+            200,
+            [],
+            ['groups' => ['club:read']]
+        );
+    }
+
+    #[Route('/me', name: 'api_club_me', methods: ['GET'])]
+    public function me(): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+        $club = $this->clubRepository->findOneBy(['user' => $user]);
+
+        if ($club === null) {
+            return $this->json(['error' => 'No club profile for this user'], 404);
+        }
+
+        return $this->json($club, 200, [], ['groups' => ['club:read']]);
+    }
+
+    #[Route('/{id}', name: 'api_club_get', methods: ['GET'], requirements: ['id' => '\d+'])]
+    public function get(Club $club): JsonResponse
+    {
+        return $this->json($club, 200, [], ['groups' => ['club:read']]);
+    }
+
+    #[Route('', name: 'api_club_create', methods: ['POST'])]
+    public function create(Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        $existing = $this->clubRepository->findOneBy(['user' => $user]);
+        if ($existing !== null) {
+            return $this->json(['error' => 'User already has a club profile'], 409);
+        }
+
+        try {
+            $club = $this->serializer->deserialize(
+                $request->getContent(),
+                Club::class,
+                'json',
+                ['groups' => ['club:write']]
+            );
+        } catch (\Throwable $e) {
+            return $this->json(['error' => 'Invalid JSON: '.$e->getMessage()], 400);
+        }
+
+        $club->setUser($user);
+
+        $errors = $this->validator->validate($club);
+        if (count($errors) > 0) {
+            return $this->json(['errors' => $this->formatErrors($errors)], 422);
+        }
+
+        $this->em->persist($club);
+        $this->em->flush();
+
+        return $this->json($club, 201, [], ['groups' => ['club:read']]);
+    }
+
+    #[Route('/{id}', name: 'api_club_update', methods: ['PATCH'], requirements: ['id' => '\d+'])]
+    public function update(Club $club, Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        if ($club->getUser() !== $user && !$this->isGranted('ROLE_ADMIN')) {
+            return $this->json(['error' => 'You can only edit your own club'], 403);
+        }
+
+        try {
+            $this->serializer->deserialize(
+                $request->getContent(),
+                Club::class,
+                'json',
+                [
+                    'groups' => ['club:write'],
+                    'object_to_populate' => $club,
+                ]
+            );
+        } catch (\Throwable $e) {
+            return $this->json(['error' => 'Invalid JSON: '.$e->getMessage()], 400);
+        }
+
+        $errors = $this->validator->validate($club);
+        if (count($errors) > 0) {
+            return $this->json(['errors' => $this->formatErrors($errors)], 422);
+        }
+
+        $this->em->flush();
+
+        return $this->json($club, 200, [], ['groups' => ['club:read']]);
+    }
+
+    #[Route('/{id}', name: 'api_club_delete', methods: ['DELETE'], requirements: ['id' => '\d+'])]
+    public function delete(Club $club): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        if ($club->getUser() !== $user && !$this->isGranted('ROLE_ADMIN')) {
+            return $this->json(['error' => 'You can only delete your own club'], 403);
+        }
+
+        $this->em->remove($club);
+        $this->em->flush();
+
+        return $this->json(null, 204);
+    }
+
+    /**
+     * @param iterable<\Symfony\Component\Validator\ConstraintViolationInterface> $errors
+     * @return array<array{field: string, message: string}>
+     */
+    private function formatErrors(iterable $errors): array
+    {
+        $result = [];
+        foreach ($errors as $error) {
+            $result[] = [
+                'field' => $error->getPropertyPath(),
+                'message' => $error->getMessage(),
+            ];
+        }
+
+        return $result;
+    }
+}

--- a/src/Controller/OfferController.php
+++ b/src/Controller/OfferController.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\Offer;
+use App\Entity\User;
+use App\Enum\PlayerRole;
+use App\Repository\ClubRepository;
+use App\Repository\OfferRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+#[Route('/api/offers')]
+class OfferController extends AbstractController
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly OfferRepository $offerRepository,
+        private readonly ClubRepository $clubRepository,
+        private readonly SerializerInterface $serializer,
+        private readonly ValidatorInterface $validator,
+    ) {
+    }
+
+    #[Route('', name: 'api_offer_list', methods: ['GET'])]
+    public function list(Request $request): JsonResponse
+    {
+        $criteria = ['isActive' => true];
+
+        $roleParam = $request->query->get('role');
+        if ($roleParam !== null) {
+            $role = PlayerRole::tryFrom($roleParam);
+            if ($role === null) {
+                return $this->json(
+                    [
+                        'error' => 'Invalid role',
+                        'allowed' => array_map(fn (PlayerRole $r) => $r->value, PlayerRole::cases()),
+                    ],
+                    400
+                );
+            }
+            $criteria['wantedRole'] = $role;
+        }
+
+        $clubId = $request->query->get('club');
+        if ($clubId !== null) {
+            $criteria['club'] = (int) $clubId;
+        }
+
+        $offers = $this->offerRepository->findBy($criteria, ['publishedAt' => 'DESC']);
+
+        return $this->json($offers, 200, [], ['groups' => ['offer:read']]);
+    }
+
+    #[Route('/{id}', name: 'api_offer_get', methods: ['GET'], requirements: ['id' => '\d+'])]
+    public function get(Offer $offer): JsonResponse
+    {
+        return $this->json($offer, 200, [], ['groups' => ['offer:read']]);
+    }
+
+    #[Route('', name: 'api_offer_create', methods: ['POST'])]
+    public function create(Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        $club = $this->clubRepository->findOneBy(['user' => $user]);
+        if ($club === null) {
+            return $this->json(['error' => 'You must have a club profile to publish offers'], 403);
+        }
+
+        try {
+            $offer = $this->serializer->deserialize(
+                $request->getContent(),
+                Offer::class,
+                'json',
+                ['groups' => ['offer:write']]
+            );
+        } catch (\Throwable $e) {
+            return $this->json(['error' => 'Invalid JSON: '.$e->getMessage()], 400);
+        }
+
+        $offer->setClub($club);
+
+        $errors = $this->validator->validate($offer);
+        if (count($errors) > 0) {
+            return $this->json(['errors' => $this->formatErrors($errors)], 422);
+        }
+
+        $this->em->persist($offer);
+        $this->em->flush();
+
+        return $this->json($offer, 201, [], ['groups' => ['offer:read']]);
+    }
+
+    #[Route('/{id}', name: 'api_offer_update', methods: ['PATCH'], requirements: ['id' => '\d+'])]
+    public function update(Offer $offer, Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        if ($offer->getClub()->getUser() !== $user && !$this->isGranted('ROLE_ADMIN')) {
+            return $this->json(['error' => 'You can only edit offers from your own club'], 403);
+        }
+
+        try {
+            $this->serializer->deserialize(
+                $request->getContent(),
+                Offer::class,
+                'json',
+                [
+                    'groups' => ['offer:write'],
+                    'object_to_populate' => $offer,
+                ]
+            );
+        } catch (\Throwable $e) {
+            return $this->json(['error' => 'Invalid JSON: '.$e->getMessage()], 400);
+        }
+
+        $errors = $this->validator->validate($offer);
+        if (count($errors) > 0) {
+            return $this->json(['errors' => $this->formatErrors($errors)], 422);
+        }
+
+        $this->em->flush();
+
+        return $this->json($offer, 200, [], ['groups' => ['offer:read']]);
+    }
+
+    #[Route('/{id}', name: 'api_offer_delete', methods: ['DELETE'], requirements: ['id' => '\d+'])]
+    public function delete(Offer $offer): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        if ($offer->getClub()->getUser() !== $user && !$this->isGranted('ROLE_ADMIN')) {
+            return $this->json(['error' => 'You can only delete offers from your own club'], 403);
+        }
+
+        $this->em->remove($offer);
+        $this->em->flush();
+
+        return $this->json(null, 204);
+    }
+
+    /**
+     * @param iterable<\Symfony\Component\Validator\ConstraintViolationInterface> $errors
+     * @return array<array{field: string, message: string}>
+     */
+    private function formatErrors(iterable $errors): array
+    {
+        $result = [];
+        foreach ($errors as $error) {
+            $result[] = [
+                'field' => $error->getPropertyPath(),
+                'message' => $error->getMessage(),
+            ];
+        }
+
+        return $result;
+    }
+}

--- a/src/Controller/PlayerController.php
+++ b/src/Controller/PlayerController.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\Player;
+use App\Entity\User;
+use App\Enum\PlayerRole;
+use App\Repository\PlayerRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+#[Route('/api/players')]
+class PlayerController extends AbstractController
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly PlayerRepository $playerRepository,
+        private readonly SerializerInterface $serializer,
+        private readonly ValidatorInterface $validator,
+    ) {
+    }
+
+    #[Route('', name: 'api_player_list', methods: ['GET'])]
+    public function list(): JsonResponse
+    {
+        $players = $this->playerRepository->findAll();
+
+        return $this->json(
+            $players,
+            200,
+            [],
+            ['groups' => ['player:read']]
+        );
+    }
+
+    #[Route('/search', name: 'api_player_search', methods: ['GET'])]
+    public function search(Request $request): JsonResponse
+    {
+        $role = $request->query->get('role');
+        $availableParam = $request->query->get('available');
+
+        $criteria = [];
+
+        if ($role !== null) {
+            $roleEnum = PlayerRole::tryFrom($role);
+            if ($roleEnum === null) {
+                return $this->json(
+                    [
+                        'error' => 'Invalid role',
+                        'allowed' => array_map(fn (PlayerRole $r) => $r->value, PlayerRole::cases()),
+                    ],
+                    400
+                );
+            }
+            $criteria['gameRole'] = $roleEnum;
+        }
+
+        if ($availableParam !== null) {
+            $criteria['isAvailable'] = filter_var($availableParam, FILTER_VALIDATE_BOOLEAN);
+        }
+
+        $players = $this->playerRepository->findBy($criteria);
+
+        return $this->json(
+            $players,
+            200,
+            [],
+            ['groups' => ['player:read']]
+        );
+    }
+
+    #[Route('/me', name: 'api_player_me', methods: ['GET'])]
+    public function me(): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+        $player = $this->playerRepository->findOneBy(['user' => $user]);
+
+        if ($player === null) {
+            return $this->json(['error' => 'No player profile for this user'], 404);
+        }
+
+        return $this->json(
+            $player,
+            200,
+            [],
+            ['groups' => ['player:read']]
+        );
+    }
+
+    #[Route('/{id}', name: 'api_player_get', methods: ['GET'], requirements: ['id' => '\d+'])]
+    public function get(Player $player): JsonResponse
+    {
+        return $this->json(
+            $player,
+            200,
+            [],
+            ['groups' => ['player:read']]
+        );
+    }
+
+    #[Route('', name: 'api_player_create', methods: ['POST'])]
+    public function create(Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        $existing = $this->playerRepository->findOneBy(['user' => $user]);
+        if ($existing !== null) {
+            return $this->json(['error' => 'User already has a player profile'], 409);
+        }
+
+        try {
+            $player = $this->serializer->deserialize(
+                $request->getContent(),
+                Player::class,
+                'json',
+                ['groups' => ['player:write']]
+            );
+        } catch (\Throwable $e) {
+            return $this->json(['error' => 'Invalid JSON: '.$e->getMessage()], 400);
+        }
+
+        $player->setUser($user);
+
+        $errors = $this->validator->validate($player);
+        if (count($errors) > 0) {
+            return $this->json(['errors' => $this->formatErrors($errors)], 422);
+        }
+
+        $this->em->persist($player);
+        $this->em->flush();
+
+        return $this->json(
+            $player,
+            201,
+            [],
+            ['groups' => ['player:read']]
+        );
+    }
+
+    #[Route('/{id}', name: 'api_player_update', methods: ['PATCH'], requirements: ['id' => '\d+'])]
+    public function update(Player $player, Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        if ($player->getUser() !== $user && !$this->isGranted('ROLE_ADMIN')) {
+            return $this->json(['error' => 'You can only edit your own player profile'], 403);
+        }
+
+        try {
+            $this->serializer->deserialize(
+                $request->getContent(),
+                Player::class,
+                'json',
+                [
+                    'groups' => ['player:write'],
+                    'object_to_populate' => $player,
+                ]
+            );
+        } catch (\Throwable $e) {
+            return $this->json(['error' => 'Invalid JSON: '.$e->getMessage()], 400);
+        }
+
+        $errors = $this->validator->validate($player);
+        if (count($errors) > 0) {
+            return $this->json(['errors' => $this->formatErrors($errors)], 422);
+        }
+
+        $this->em->flush();
+
+        return $this->json(
+            $player,
+            200,
+            [],
+            ['groups' => ['player:read']]
+        );
+    }
+
+    #[Route('/{id}', name: 'api_player_delete', methods: ['DELETE'], requirements: ['id' => '\d+'])]
+    public function delete(Player $player): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        if ($player->getUser() !== $user && !$this->isGranted('ROLE_ADMIN')) {
+            return $this->json(['error' => 'You can only delete your own player profile'], 403);
+        }
+
+        $this->em->remove($player);
+        $this->em->flush();
+
+        return $this->json(null, 204);
+    }
+
+    /**
+     * @param iterable<\Symfony\Component\Validator\ConstraintViolationInterface> $errors
+     * @return array<array{field: string, message: string}>
+     */
+    private function formatErrors(iterable $errors): array
+    {
+        $result = [];
+        foreach ($errors as $error) {
+            $result[] = [
+                'field' => $error->getPropertyPath(),
+                'message' => $error->getMessage(),
+            ];
+        }
+
+        return $result;
+    }
+}

--- a/src/Entity/Club.php
+++ b/src/Entity/Club.php
@@ -6,6 +6,8 @@ namespace App\Entity;
 
 use App\Repository\ClubRepository;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: ClubRepository::class)]
 class Club
@@ -13,21 +15,32 @@ class Club
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
+    #[Groups(['club:read', 'offer:read'])]
     private ?int $id = null;
 
     #[ORM\Column(length: 150)]
+    #[Assert\NotBlank]
+    #[Assert\Length(min: 2, max: 150)]
+    #[Groups(['club:read', 'club:write', 'offer:read'])]
     private ?string $name = null;
 
     #[ORM\Column(type: 'text', nullable: true)]
+    #[Assert\Length(max: 5000)]
+    #[Groups(['club:read', 'club:write'])]
     private ?string $description = null;
 
     #[ORM\Column(length: 255, nullable: true)]
+    #[Assert\Url]
+    #[Groups(['club:read', 'club:write'])]
     private ?string $logoUrl = null;
 
     #[ORM\Column(length: 255, nullable: true)]
+    #[Assert\Url]
+    #[Groups(['club:read', 'club:write'])]
     private ?string $website = null;
 
     #[ORM\Column]
+    #[Groups(['club:read'])]
     private bool $isVerified = false;
 
     #[ORM\OneToOne]

--- a/src/Entity/Offer.php
+++ b/src/Entity/Offer.php
@@ -7,6 +7,8 @@ namespace App\Entity;
 use App\Enum\PlayerRole;
 use App\Repository\OfferRepository;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: OfferRepository::class)]
 class Offer
@@ -14,31 +16,47 @@ class Offer
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
+    #[Groups(['offer:read'])]
     private ?int $id = null;
 
     #[ORM\Column(length: 150)]
+    #[Assert\NotBlank]
+    #[Assert\Length(min: 3, max: 150)]
+    #[Groups(['offer:read', 'offer:write'])]
     private ?string $title = null;
 
     #[ORM\Column(type: 'text')]
+    #[Assert\NotBlank]
+    #[Assert\Length(min: 10, max: 5000)]
+    #[Groups(['offer:read', 'offer:write'])]
     private ?string $description = null;
 
     #[ORM\Column(enumType: PlayerRole::class)]
+    #[Assert\NotNull]
+    #[Groups(['offer:read', 'offer:write'])]
     private ?PlayerRole $wantedRole = null;
 
     #[ORM\Column(length: 50)]
+    #[Assert\NotBlank]
+    #[Groups(['offer:read', 'offer:write'])]
     private ?string $minimumRank = null;
 
     #[ORM\Column]
+    #[Groups(['offer:read'])]
     private \DateTimeImmutable $publishedAt;
 
     #[ORM\Column(type: 'date_immutable', nullable: true)]
+    #[Assert\GreaterThan('today')]
+    #[Groups(['offer:read', 'offer:write'])]
     private ?\DateTimeImmutable $expiresAt = null;
 
     #[ORM\Column]
+    #[Groups(['offer:read', 'offer:write'])]
     private bool $isActive = true;
 
     #[ORM\ManyToOne]
     #[ORM\JoinColumn(nullable: false)]
+    #[Groups(['offer:read'])]
     private ?Club $club = null;
 
     public function __construct()

--- a/src/Entity/Player.php
+++ b/src/Entity/Player.php
@@ -7,6 +7,8 @@ namespace App\Entity;
 use App\Enum\PlayerRole;
 use App\Repository\PlayerRepository;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: PlayerRepository::class)]
 class Player
@@ -14,24 +16,39 @@ class Player
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
+    #[Groups(['player:read'])]
     private ?int $id = null;
 
     #[ORM\Column(length: 100)]
+    #[Assert\NotBlank]
+    #[Assert\Length(min: 2, max: 100)]
+    #[Groups(['player:read', 'player:write'])]
     private ?string $pseudo = null;
 
     #[ORM\Column(length: 100)]
+    #[Assert\NotBlank]
+    #[Assert\Length(min: 1, max: 100)]
+    #[Groups(['player:read', 'player:write'])]
     private ?string $firstName = null;
 
     #[ORM\Column(length: 100)]
+    #[Assert\NotBlank]
+    #[Assert\Length(min: 1, max: 100)]
+    #[Groups(['player:read', 'player:write'])]
     private ?string $lastName = null;
 
     #[ORM\Column(enumType: PlayerRole::class)]
+    #[Assert\NotNull]
+    #[Groups(['player:read', 'player:write'])]
     private ?PlayerRole $gameRole = null;
 
     #[ORM\Column]
+    #[Groups(['player:read', 'player:write'])]
     private bool $isAvailable = true;
 
     #[ORM\Column(type: 'text', nullable: true)]
+    #[Assert\Length(max: 2000)]
+    #[Groups(['player:read', 'player:write'])]
     private ?string $bio = null;
 
     #[ORM\OneToOne]

--- a/symfony.lock
+++ b/symfony.lock
@@ -47,6 +47,18 @@
             "config/packages/lexik_jwt_authentication.yaml"
         ]
     },
+    "nelmio/cors-bundle": {
+        "version": "2.6",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "1.5",
+            "ref": "6bea22e6c564fba3a1391615cada1437d0bde39c"
+        },
+        "files": [
+            "config/packages/nelmio_cors.yaml"
+        ]
+    },
     "symfony/console": {
         "version": "7.2",
         "recipe": {
@@ -124,6 +136,18 @@
         "files": [
             "config/packages/security.yaml",
             "config/routes/security.yaml"
+        ]
+    },
+    "symfony/validator": {
+        "version": "7.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "7.0",
+            "ref": "8c1c4e28d26a124b0bb273f537ca8ce443472bfd"
+        },
+        "files": [
+            "config/packages/validator.yaml"
         ]
     }
 }


### PR DESCRIPTION
…ation

- Install nelmio/cors-bundle (allows all localhost:* for dev), symfony/serializer, symfony/validator
- Add serialization groups on entities:
  * Player: player:read / player:write
  * Club: club:read / club:write / offer:read (minimal id+name exposed when embedded in Offer)
  * Offer: offer:read / offer:write
- Add validation constraints (NotBlank, Length, NotNull, Url, GreaterThan)

Controllers (all /api/* protected by JWT firewall):
- PlayerController: GET list, GET /{id}, GET /me, GET /search (?role=ADC&available=true), POST, PATCH, DELETE
- ClubController: GET list, GET /{id}, GET /me, POST, PATCH, DELETE
- OfferController: GET list (filters ?role=&club=, ordered by publishedAt DESC), GET /{id}, POST (requires club profile), PATCH, DELETE

Permissions:
- Users can only update/delete their own Player/Club
- Offers can only be edited/deleted by the owning club's user
- ROLE_ADMIN bypasses ownership checks
- Only one Player or Club per User enforced at creation (409 Conflict)

Response codes: 200 OK, 201 Created, 204 No Content, 400 Bad Request, 403 Forbidden, 404 Not Found, 409 Conflict, 422 Unprocessable Entity (validation errors)

Tested manually: CRUD flows + validation + CORS preflight from http://localhost:5173