### PR TITLE
feat: entite Application + ApplicationController (#14)

### DIFF
--- a/migrations/Version20260527055707.php
+++ b/migrations/Version20260527055707.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260527055707 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE application (id INT AUTO_INCREMENT NOT NULL, message LONGTEXT DEFAULT NULL, status VARCHAR(255) NOT NULL, applied_at DATETIME NOT NULL, player_id INT NOT NULL, offer_id INT NOT NULL, INDEX IDX_A45BDDC199E6F5DF (player_id), INDEX IDX_A45BDDC153C674EE (offer_id), UNIQUE INDEX uniq_player_offer (player_id, offer_id), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci`');
+        $this->addSql('ALTER TABLE application ADD CONSTRAINT FK_A45BDDC199E6F5DF FOREIGN KEY (player_id) REFERENCES player (id)');
+        $this->addSql('ALTER TABLE application ADD CONSTRAINT FK_A45BDDC153C674EE FOREIGN KEY (offer_id) REFERENCES offer (id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE application DROP FOREIGN KEY FK_A45BDDC199E6F5DF');
+        $this->addSql('ALTER TABLE application DROP FOREIGN KEY FK_A45BDDC153C674EE');
+        $this->addSql('DROP TABLE application');
+    }
+}

--- a/src/Controller/ApplicationController.php
+++ b/src/Controller/ApplicationController.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\Application;
+use App\Entity\User;
+use App\Enum\ApplicationStatus;
+use App\Repository\ApplicationRepository;
+use App\Repository\ClubRepository;
+use App\Repository\OfferRepository;
+use App\Repository\PlayerRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+#[Route('/api')]
+class ApplicationController extends AbstractController
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly ApplicationRepository $applicationRepository,
+        private readonly OfferRepository $offerRepository,
+        private readonly PlayerRepository $playerRepository,
+        private readonly ClubRepository $clubRepository,
+        private readonly ValidatorInterface $validator,
+    ) {
+    }
+
+    /**
+     * POST /api/applications
+     * Un joueur authentifié postule à une offre.
+     * Body : { "offerId": 42, "message": "Bonjour..." }
+     */
+    #[Route('/applications', name: 'api_application_create', methods: ['POST'])]
+    public function create(Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        // Seul un joueur peut postuler
+        $player = $this->playerRepository->findOneBy(['user' => $user]);
+        if ($player === null) {
+            return $this->json(['error' => 'Only players can apply to offers'], 403);
+        }
+
+        $data = json_decode($request->getContent(), true);
+        if (!is_array($data)) {
+            return $this->json(['error' => 'Invalid JSON body'], 400);
+        }
+
+        $offerId = $data['offerId'] ?? null;
+        if (!is_int($offerId) && !ctype_digit((string) $offerId)) {
+            return $this->json(['error' => 'offerId is required and must be an integer'], 400);
+        }
+
+        $offer = $this->offerRepository->find((int) $offerId);
+        if ($offer === null) {
+            return $this->json(['error' => 'Offer not found'], 404);
+        }
+        if (!$offer->isActive()) {
+            return $this->json(['error' => 'This offer is no longer active'], 409);
+        }
+
+        // Empêche les doubles candidatures (au niveau applicatif, en plus de la contrainte BDD)
+        $existing = $this->applicationRepository->findOneBy(['player' => $player, 'offer' => $offer]);
+        if ($existing !== null) {
+            return $this->json(['error' => 'You already applied to this offer'], 409);
+        }
+
+        $application = new Application();
+        $application->setPlayer($player);
+        $application->setOffer($offer);
+        $application->setMessage($data['message'] ?? null);
+
+        $errors = $this->validator->validate($application);
+        if (count($errors) > 0) {
+            return $this->json(['errors' => $this->formatErrors($errors)], 422);
+        }
+
+        $this->em->persist($application);
+        $this->em->flush();
+
+        return $this->json($application, 201, [], ['groups' => ['application:read']]);
+    }
+
+    /**
+     * GET /api/applications/me
+     * Liste les candidatures envoyées par le joueur authentifié.
+     */
+    #[Route('/applications/me', name: 'api_application_list_mine', methods: ['GET'])]
+    public function listMine(): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        $player = $this->playerRepository->findOneBy(['user' => $user]);
+        if ($player === null) {
+            return $this->json(['error' => 'You must have a player profile'], 403);
+        }
+
+        $applications = $this->applicationRepository->findByPlayer($player);
+
+        return $this->json($applications, 200, [], ['groups' => ['application:read']]);
+    }
+
+    /**
+     * GET /api/clubs/me/applications
+     * Liste les candidatures reçues sur les offres du club authentifié.
+     */
+    #[Route('/clubs/me/applications', name: 'api_application_list_for_club', methods: ['GET'])]
+    public function listForClub(): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        $club = $this->clubRepository->findOneBy(['user' => $user]);
+        if ($club === null) {
+            return $this->json(['error' => 'You must have a club profile'], 403);
+        }
+
+        $applications = $this->applicationRepository->findByClub($club);
+
+        return $this->json($applications, 200, [], ['groups' => ['application:read']]);
+    }
+
+    /**
+     * PATCH /api/applications/{id}
+     * Met à jour le statut (ACCEPTEE / REFUSEE).
+     * Réservé au club propriétaire de l'offre.
+     * Body : { "status": "ACCEPTEE" }
+     */
+    #[Route('/applications/{id}', name: 'api_application_update_status', methods: ['PATCH'], requirements: ['id' => '\d+'])]
+    public function updateStatus(Application $application, Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        // Seul le club propriétaire de l'offre peut changer le statut
+        $offerClub = $application->getOffer()?->getClub();
+        if ($offerClub === null || $offerClub->getUser() !== $user) {
+            return $this->json(['error' => 'Only the club owning the offer can update applications'], 403);
+        }
+
+        $data = json_decode($request->getContent(), true);
+        if (!is_array($data)) {
+            return $this->json(['error' => 'Invalid JSON body'], 400);
+        }
+
+        $statusValue = $data['status'] ?? null;
+        $status = is_string($statusValue) ? ApplicationStatus::tryFrom($statusValue) : null;
+        if ($status === null) {
+            return $this->json(
+                [
+                    'error' => 'Invalid status',
+                    'allowed' => array_map(fn (ApplicationStatus $s) => $s->value, ApplicationStatus::cases()),
+                ],
+                400
+            );
+        }
+
+        $application->setStatus($status);
+        $this->em->flush();
+
+        return $this->json($application, 200, [], ['groups' => ['application:read']]);
+    }
+
+    /**
+     * @param iterable<\Symfony\Component\Validator\ConstraintViolationInterface> $errors
+     * @return array<array{field: string, message: string}>
+     */
+    private function formatErrors(iterable $errors): array
+    {
+        $result = [];
+        foreach ($errors as $error) {
+            $result[] = [
+                'field' => $error->getPropertyPath(),
+                'message' => $error->getMessage(),
+            ];
+        }
+
+        return $result;
+    }
+}

--- a/src/Entity/Application.php
+++ b/src/Entity/Application.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Enum\ApplicationStatus;
+use App\Repository\ApplicationRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ORM\Entity(repositoryClass: ApplicationRepository::class)]
+#[ORM\UniqueConstraint(name: 'uniq_player_offer', columns: ['player_id', 'offer_id'])]
+#[ORM\Table(name: 'application')]
+class Application
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    #[Groups(['application:read'])]
+    private ?int $id = null;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    #[Assert\Length(
+        min: 10,
+        max: 2000,
+        minMessage: 'Le message de motivation doit faire au moins 10 caractères',
+        maxMessage: 'Le message ne peut excéder 2000 caractères'
+    )]
+    #[Groups(['application:read', 'application:write'])]
+    private ?string $message = null;
+
+    #[ORM\Column(enumType: ApplicationStatus::class)]
+    #[Groups(['application:read'])]
+    private ApplicationStatus $status = ApplicationStatus::EN_ATTENTE;
+
+    #[ORM\Column]
+    #[Groups(['application:read'])]
+    private \DateTimeImmutable $appliedAt;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: false)]
+    #[Groups(['application:read'])]
+    private ?Player $player = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: false)]
+    #[Groups(['application:read'])]
+    private ?Offer $offer = null;
+
+    public function __construct()
+    {
+        $this->appliedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getMessage(): ?string
+    {
+        return $this->message;
+    }
+
+    public function setMessage(?string $message): static
+    {
+        $this->message = $message;
+
+        return $this;
+    }
+
+    public function getStatus(): ApplicationStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(ApplicationStatus $status): static
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    public function getAppliedAt(): \DateTimeImmutable
+    {
+        return $this->appliedAt;
+    }
+
+    public function getPlayer(): ?Player
+    {
+        return $this->player;
+    }
+
+    public function setPlayer(Player $player): static
+    {
+        $this->player = $player;
+
+        return $this;
+    }
+
+    public function getOffer(): ?Offer
+    {
+        return $this->offer;
+    }
+
+    public function setOffer(Offer $offer): static
+    {
+        $this->offer = $offer;
+
+        return $this;
+    }
+}

--- a/src/Enum/ApplicationStatus.php
+++ b/src/Enum/ApplicationStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+enum ApplicationStatus: string
+{
+    case EN_ATTENTE = 'EN_ATTENTE';
+    case ACCEPTEE = 'ACCEPTEE';
+    case REFUSEE = 'REFUSEE';
+}

--- a/src/Repository/ApplicationRepository.php
+++ b/src/Repository/ApplicationRepository.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\Application;
+use App\Entity\Club;
+use App\Entity\Player;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Application>
+ */
+class ApplicationRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Application::class);
+    }
+
+    /**
+     * Toutes les candidatures envoyées par un joueur.
+     *
+     * @return Application[]
+     */
+    public function findByPlayer(Player $player): array
+    {
+        return $this->createQueryBuilder('a')
+            ->andWhere('a.player = :player')
+            ->setParameter('player', $player)
+            ->orderBy('a.appliedAt', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * Toutes les candidatures reçues sur les offres d'un club.
+     *
+     * @return Application[]
+     */
+    public function findByClub(Club $club): array
+    {
+        return $this->createQueryBuilder('a')
+            ->innerJoin('a.offer', 'o')
+            ->andWhere('o.club = :club')
+            ->setParameter('club', $club)
+            ->orderBy('a.appliedAt', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
+}


### PR DESCRIPTION
Closes #14

## Résumé
Ajout du système de candidature côté back : une entité `Application` qui relie un `Player` à une `Offer`, avec un statut (`EN_ATTENTE` / `ACCEPTEE` / `REFUSEE`) et un message de motivation.

## Détails

### Modèle
- Enum `ApplicationStatus`
- Entité `Application` avec contrainte `UNIQUE(player_id, offer_id)` → empêche les doubles candidatures
- Relations `ManyToOne` vers `Player` et `Offer`
- Validation : message entre 10 et 2000 caractères
- Migration `Version20260527055707` (CREATE TABLE + FK + unique index)

### Endpoints REST
| Méthode | Route | Rôle |
|---|---|---|
| POST | `/api/applications` | Joueur authentifié uniquement |
| GET | `/api/applications/me` | Joueur authentifié (ses candidatures) |
| GET | `/api/clubs/me/applications` | Club authentifié (candidatures reçues) |
| PATCH | `/api/applications/{id}` | Club propriétaire de l'offre uniquement |

### Sécurité
- Le firewall Symfony renvoie 401 sans JWT (vérifié)
- Vérification applicative que l'offre est toujours active avant d'accepter une candidature
- Vérification que seul le club propriétaire peut changer le statut

## Test plan
- [x] Routes enregistrées (`debug:router`)
- [x] Migration applique correctement
- [x] Smoke test : appels sans auth → HTTP 401
- [ ] Test E2E avec données réelles (à faire après création des fixtures, prévu J3)