### PR TITLE
feat: fixtures de demo (#18)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,6 +81,7 @@
         }
     },
     "require-dev": {
+        "doctrine/doctrine-fixtures-bundle": "^4.3",
         "symfony/maker-bundle": "^1.67"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bc65ca3b2f1cba2928dd0ca317606cb4",
+    "content-hash": "3aaaf3a3117d77fc9554aedd96f16c70",
     "packages": [
         {
             "name": "doctrine/collections",
@@ -5543,6 +5543,177 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "doctrine/data-fixtures",
+            "version": "2.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/data-fixtures.git",
+                "reference": "bf7ac3a050b54b261cedfb3d0a44733819062275"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/data-fixtures/zipball/bf7ac3a050b54b261cedfb3d0a44733819062275",
+                "reference": "bf7ac3a050b54b261cedfb3d0a44733819062275",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/persistence": "^3.1 || ^4.0",
+                "php": "^8.1",
+                "psr/log": "^1.1 || ^2 || ^3"
+            },
+            "conflict": {
+                "doctrine/dbal": "<3.5 || >=5",
+                "doctrine/orm": "<2.14 || >=4",
+                "doctrine/phpcr-odm": "<1.3.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "doctrine/dbal": "^3.5 || ^4",
+                "doctrine/mongodb-odm": "^1.3.0 || ^2.0.0",
+                "doctrine/orm": "^2.14 || ^3",
+                "doctrine/phpcr-odm": "^1.8 || ^2.0",
+                "ext-sqlite3": "*",
+                "fig/log-test": "^1",
+                "jackalope/jackalope-fs": "*",
+                "phpstan/phpstan": "2.1.46",
+                "phpunit/phpunit": "10.5.63 || 12.5.12",
+                "symfony/cache": "^6.4 || ^7 || ^8",
+                "symfony/var-exporter": "^6.4 || ^7 || ^8"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "For using MongoDB ODM 1.3 with PHP 7 (deprecated)",
+                "doctrine/mongodb-odm": "For loading MongoDB ODM fixtures",
+                "doctrine/orm": "For loading ORM fixtures",
+                "doctrine/phpcr-odm": "For loading PHPCR ODM fixtures"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\DataFixtures\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Data Fixtures for all Doctrine Object Managers",
+            "homepage": "https://www.doctrine-project.org",
+            "keywords": [
+                "database"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/data-fixtures/issues",
+                "source": "https://github.com/doctrine/data-fixtures/tree/2.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdata-fixtures",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-01T13:56:01+00:00"
+        },
+        {
+            "name": "doctrine/doctrine-fixtures-bundle",
+            "version": "4.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/DoctrineFixturesBundle.git",
+                "reference": "9e013ed10d49bf7746b07204d336384a7d9b5a4d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/DoctrineFixturesBundle/zipball/9e013ed10d49bf7746b07204d336384a7d9b5a4d",
+                "reference": "9e013ed10d49bf7746b07204d336384a7d9b5a4d",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/data-fixtures": "^2.2",
+                "doctrine/doctrine-bundle": "^2.2 || ^3.0",
+                "doctrine/orm": "^2.14.0 || ^3.0",
+                "doctrine/persistence": "^2.4 || ^3.0 || ^4.0",
+                "php": "^8.1",
+                "psr/log": "^2 || ^3",
+                "symfony/config": "^6.4 || ^7.0 || ^8.0",
+                "symfony/console": "^6.4 || ^7.0 || ^8.0",
+                "symfony/dependency-injection": "^6.4 || ^7.0 || ^8.0",
+                "symfony/deprecation-contracts": "^2.1 || ^3",
+                "symfony/doctrine-bridge": "^6.4.16 || ^7.1.9 || ^8.0",
+                "symfony/http-kernel": "^6.4 || ^7.0 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/dbal": "< 3"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "14.0.0",
+                "phpstan/phpstan": "2.1.11",
+                "phpunit/phpunit": "^10.5.38 || 11.4.14"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Bundle\\FixturesBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Doctrine Project",
+                    "homepage": "https://www.doctrine-project.org"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony DoctrineFixturesBundle",
+            "homepage": "https://www.doctrine-project.org",
+            "keywords": [
+                "Fixture",
+                "persistence"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/DoctrineFixturesBundle/issues",
+                "source": "https://github.com/doctrine/DoctrineFixturesBundle/tree/4.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdoctrine-fixtures-bundle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-03T16:05:42+00:00"
+        },
         {
             "name": "nikic/php-parser",
             "version": "v5.7.0",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -8,4 +8,5 @@ return [
     Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
     Lexik\Bundle\JWTAuthenticationBundle\LexikJWTAuthenticationBundle::class => ['all' => true],
     Nelmio\CorsBundle\NelmioCorsBundle::class => ['all' => true],
+    Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['dev' => true, 'test' => true],
 ];

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataFixtures;
+
+use App\Entity\Application;
+use App\Entity\Club;
+use App\Entity\Offer;
+use App\Entity\PlayedChampion;
+use App\Entity\Player;
+use App\Entity\PlayerStats;
+use App\Entity\RiotAccount;
+use App\Entity\User;
+use App\Enum\ApplicationStatus;
+use App\Enum\PlayerRole;
+use App\Enum\UserRole;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Données de démo pour LoL Scout.
+ * Mot de passe commun à tous les comptes : "password"
+ *
+ * Chargement : docker compose exec php php bin/console doctrine:fixtures:load
+ */
+class AppFixtures extends Fixture
+{
+    public function __construct(
+        private readonly UserPasswordHasherInterface $hasher,
+    ) {
+    }
+
+    public function load(ObjectManager $manager): void
+    {
+        // ─── ADMIN ──────────────────────────────────────────
+        $admin = $this->createUser('admin@lolscout.gg', UserRole::ADMIN);
+        $manager->persist($admin);
+
+        // ─── JOUEURS ────────────────────────────────────────
+        $playersData = [
+            ['ShadowMid',   'Lucas',  'Martin',   PlayerRole::MID,     'Diamond II',  56.3, 142, ['Ahri', 'Syndra', 'Yasuo'], true],
+            ['JungleKing',  'Hugo',   'Bernard',  PlayerRole::JUNGLE,  'Master I',    61.0, 230, ['Lee Sin', 'Elise', 'Graves'], true],
+            ['TopDiff',     'Noah',   'Dubois',   PlayerRole::TOP,     'Diamond IV',  52.1, 98,  ['Darius', 'Garen', 'Sett'], true],
+            ['ADCarry',     'Emma',   'Petit',    PlayerRole::ADC,     'Emerald I',   54.8, 176, ['Jinx', 'Caitlyn', 'Ezreal'], false],
+            ['SupDiffAndy', 'Léa',    'Robert',   PlayerRole::SUPPORT, 'Platinum II', 49.2, 203, ['Thresh', 'Lulu', 'Nautilus'], true],
+            ['FaastHands',  'Tom',    'Richard',  PlayerRole::MID,     'Grandmaster', 63.5, 312, ['Zed', 'Akali', 'LeBlanc'], true],
+        ];
+
+        $players = [];
+        foreach ($playersData as $i => $data) {
+            [$pseudo, $firstName, $lastName, $role, $tier, $winrate, $games, $champions, $available] = $data;
+
+            $user = $this->createUser(sprintf('joueur%d@lolscout.gg', $i + 1), UserRole::PLAYER);
+            $manager->persist($user);
+
+            $player = new Player();
+            $player->setUser($user)
+                ->setPseudo($pseudo)
+                ->setFirstName($firstName)
+                ->setLastName($lastName)
+                ->setGameRole($role)
+                ->setIsAvailable($available)
+                ->setBio(sprintf('Joueur %s passionné, %s sur EUW. À la recherche d\'une équipe sérieuse pour la prochaine saison.', $role->value, $tier));
+            $manager->persist($player);
+
+            // Compte Riot + stats associées
+            $riotAccount = new RiotAccount();
+            $riotAccount->setPlayer($player)
+                ->setSummonerName($pseudo.'#EUW')
+                ->setPuuid('demo-puuid-'.uniqid())
+                ->setRegion('EUW1')
+                ->setLastSyncAt(new \DateTimeImmutable());
+            $manager->persist($riotAccount);
+
+            $stats = new PlayerStats();
+            $stats->setRiotAccount($riotAccount)
+                ->setTier($tier)
+                ->setWinrate((string) $winrate)
+                ->setAverageKda((string) round(mt_rand(180, 420) / 100, 2))
+                ->setCsPerMinute((string) round(mt_rand(550, 850) / 100, 2))
+                ->setVisionScore((string) round(mt_rand(1500, 4500) / 100, 2))
+                ->setRankedGamesCount($games);
+            $manager->persist($stats);
+
+            foreach ($champions as $champName) {
+                $champ = new PlayedChampion();
+                $champ->setPlayerStats($stats)
+                    ->setChampionName($champName)
+                    ->setGamesPlayed(mt_rand(20, 80))
+                    ->setWinrate((string) round(mt_rand(4500, 6500) / 100, 2))
+                    ->setKda((string) round(mt_rand(200, 450) / 100, 2));
+                $manager->persist($champ);
+            }
+
+            $players[] = $player;
+        }
+
+        // ─── CLUBS ──────────────────────────────────────────
+        $clubsData = [
+            ['Phoenix Esport',  'Structure semi-pro fondée en 2023, on vise la LFL2.', true],
+            ['Nova Gaming',     'Équipe amateur ambitieuse cherchant à monter en division.', true],
+            ['Shadow Wolves',   'Collectif esport convivial, ambiance avant tout.', false],
+        ];
+
+        $clubs = [];
+        foreach ($clubsData as $i => $data) {
+            [$name, $description, $verified] = $data;
+
+            $user = $this->createUser(sprintf('club%d@lolscout.gg', $i + 1), UserRole::CLUB);
+            $manager->persist($user);
+
+            $club = new Club();
+            $club->setUser($user)
+                ->setName($name)
+                ->setDescription($description)
+                ->setWebsite('https://'.strtolower(str_replace(' ', '', $name)).'.gg')
+                ->setIsVerified($verified);
+            $manager->persist($club);
+
+            $clubs[] = $club;
+        }
+
+        // ─── OFFRES ─────────────────────────────────────────
+        $offersData = [
+            [0, 'Recherche MID Diamond+ pour roster compétitif', PlayerRole::MID,     'Diamond IV',  true],
+            [0, 'JUNGLE Master minimum pour scrims quotidiens',   PlayerRole::JUNGLE,  'Master I',    true],
+            [1, 'ADC Emerald+ motivé pour la saison',             PlayerRole::ADC,     'Emerald I',   true],
+            [1, 'SUPPORT recherché — ambiance sérieuse',          PlayerRole::SUPPORT, 'Platinum I',  true],
+            [2, 'TOP laner pour équipe amateur (closed)',         PlayerRole::TOP,     'Gold I',      false],
+        ];
+
+        $offers = [];
+        foreach ($offersData as $data) {
+            [$clubIndex, $title, $role, $minRank, $active] = $data;
+
+            $offer = new Offer();
+            $offer->setClub($clubs[$clubIndex])
+                ->setTitle($title)
+                ->setDescription(sprintf('Nous recherchons un joueur %s de niveau %s minimum, disponible en soirée pour les entraînements. Bonne mentalité exigée, esprit d\'équipe indispensable. Contacte-nous via la plateforme !', $role->value, $minRank))
+                ->setWantedRole($role)
+                ->setMinimumRank($minRank)
+                ->setExpiresAt(new \DateTimeImmutable('+30 days'))
+                ->setIsActive($active);
+            $manager->persist($offer);
+
+            $offers[] = $offer;
+        }
+
+        // ─── CANDIDATURES ───────────────────────────────────
+        $applicationsData = [
+            [0, 0, ApplicationStatus::EN_ATTENTE, 'Bonjour, je suis MID Diamond II avec 56% de winrate. Très motivé pour rejoindre un roster compétitif !'],
+            [5, 0, ApplicationStatus::ACCEPTEE,   'Grandmaster MID, je cherche un projet sérieux. Disponible tous les soirs.'],
+            [3, 2, ApplicationStatus::EN_ATTENTE, 'ADC Emerald I, mains Jinx/Caitlyn. Je peux faire un essai quand vous voulez.'],
+            [4, 3, ApplicationStatus::REFUSEE,    'Support Platinum II, dispo en soirée pour les scrims.'],
+            [1, 1, ApplicationStatus::EN_ATTENTE, 'Jungle Master I, 61% WR sur 230 games. Je connais bien la macro et le pathing.'],
+        ];
+
+        foreach ($applicationsData as $data) {
+            [$playerIndex, $offerIndex, $status, $message] = $data;
+
+            $application = new Application();
+            $application->setPlayer($players[$playerIndex])
+                ->setOffer($offers[$offerIndex])
+                ->setMessage($message)
+                ->setStatus($status);
+            $manager->persist($application);
+        }
+
+        $manager->flush();
+    }
+
+    private function createUser(string $email, UserRole $role): User
+    {
+        $user = new User();
+        $user->setEmail($email)
+            ->setRole($role);
+        $user->setPassword($this->hasher->hashPassword($user, 'password'));
+
+        return $user;
+    }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -22,6 +22,18 @@
             "src/Repository/.gitignore"
         ]
     },
+    "doctrine/doctrine-fixtures-bundle": {
+        "version": "4.3",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "3.0",
+            "ref": "1f5514cfa15b947298df4d771e694e578d4c204d"
+        },
+        "files": [
+            "src/DataFixtures/AppFixtures.php"
+        ]
+    },
     "doctrine/doctrine-migrations-bundle": {
         "version": "3.7",
         "recipe": {


### PR DESCRIPTION
Refs #18

## Résumé
Données de démo pour pouvoir tester tout le flow en local sans la clé Riot.

## Contenu
- `doctrine/doctrine-fixtures-bundle` installé
- `AppFixtures` : 1 admin + 6 joueurs + 3 clubs + 5 offres + 5 candidatures
- Chaque joueur a un RiotAccount + PlayerStats + 3 champions joués
- Mot de passe commun à tous les comptes : `password`

## Comptes de démo
- `joueur1@lolscout.gg` → `joueur6@lolscout.gg`
- `club1@lolscout.gg` → `club3@lolscout.gg`
- `admin@lolscout.gg`

## Test plan
- [x] `doctrine:fixtures:load` OK
- [x] Comptage BDD : 10 users, 6 players, 3 clubs, 5 offers, 5 applications, 18 champions
- [x] Flow E2E : login JWT + GET /api/players/me → profil renvoyé

> Note : voters Symfony + recherche par rang reportés (la sécurité est déjà assurée par des checks inline ; ces tâches sont de la polish non bloquante).