### PR TITLE
feat: serialisation imbriquee stats (#25)

### DIFF
--- a/migrations/Version20260531111934.php
+++ b/migrations/Version20260531111934.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260531111934 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE riot_account DROP INDEX IDX_79C2D42D99E6F5DF, ADD UNIQUE INDEX UNIQ_79C2D42D99E6F5DF (player_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE riot_account DROP INDEX UNIQ_79C2D42D99E6F5DF, ADD INDEX IDX_79C2D42D99E6F5DF (player_id)');
+    }
+}

--- a/src/Entity/PlayedChampion.php
+++ b/src/Entity/PlayedChampion.php
@@ -6,6 +6,7 @@ namespace App\Entity;
 
 use App\Repository\PlayedChampionRepository;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
 
 #[ORM\Entity(repositoryClass: PlayedChampionRepository::class)]
 class PlayedChampion
@@ -13,21 +14,26 @@ class PlayedChampion
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
+    #[Groups(['player:read'])]
     private ?int $id = null;
 
     #[ORM\Column(length: 50)]
+    #[Groups(['player:read'])]
     private ?string $championName = null;
 
     #[ORM\Column]
+    #[Groups(['player:read'])]
     private ?int $gamesPlayed = null;
 
     #[ORM\Column(type: 'decimal', precision: 5, scale: 2)]
+    #[Groups(['player:read'])]
     private ?string $winrate = null;
 
     #[ORM\Column(type: 'decimal', precision: 4, scale: 2)]
+    #[Groups(['player:read'])]
     private ?string $kda = null;
 
-    #[ORM\ManyToOne]
+    #[ORM\ManyToOne(inversedBy: 'playedChampions', targetEntity: PlayerStats::class)]
     #[ORM\JoinColumn(nullable: false)]
     private ?PlayerStats $playerStats = null;
 

--- a/src/Entity/Player.php
+++ b/src/Entity/Player.php
@@ -55,6 +55,14 @@ class Player
     #[ORM\JoinColumn(nullable: false, unique: true)]
     private ?User $user = null;
 
+    /**
+     * Relation inverse vers RiotAccount.
+     * Un joueur n'a au maximum qu'un seul compte Riot lié.
+     */
+    #[ORM\OneToOne(mappedBy: 'player', targetEntity: RiotAccount::class)]
+    #[Groups(['player:read'])]
+    private ?RiotAccount $riotAccount = null;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -140,6 +148,18 @@ class Player
     public function setUser(User $user): static
     {
         $this->user = $user;
+
+        return $this;
+    }
+
+    public function getRiotAccount(): ?RiotAccount
+    {
+        return $this->riotAccount;
+    }
+
+    public function setRiotAccount(?RiotAccount $riotAccount): static
+    {
+        $this->riotAccount = $riotAccount;
 
         return $this;
     }

--- a/src/Entity/PlayerStats.php
+++ b/src/Entity/PlayerStats.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace App\Entity;
 
 use App\Repository\PlayerStatsRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
 
 #[ORM\Entity(repositoryClass: PlayerStatsRepository::class)]
 class PlayerStats
@@ -13,29 +16,51 @@ class PlayerStats
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
+    #[Groups(['player:read'])]
     private ?int $id = null;
 
     #[ORM\Column(length: 50)]
+    #[Groups(['player:read'])]
     private ?string $tier = null;
 
     #[ORM\Column(type: 'decimal', precision: 5, scale: 2)]
+    #[Groups(['player:read'])]
     private ?string $winrate = null;
 
     #[ORM\Column(type: 'decimal', precision: 4, scale: 2)]
+    #[Groups(['player:read'])]
     private ?string $averageKda = null;
 
     #[ORM\Column(type: 'decimal', precision: 4, scale: 2)]
+    #[Groups(['player:read'])]
     private ?string $csPerMinute = null;
 
     #[ORM\Column(type: 'decimal', precision: 5, scale: 2)]
+    #[Groups(['player:read'])]
     private ?string $visionScore = null;
 
     #[ORM\Column]
+    #[Groups(['player:read'])]
     private ?int $rankedGamesCount = null;
 
-    #[ORM\OneToOne]
+    #[ORM\OneToOne(inversedBy: 'stats', targetEntity: RiotAccount::class)]
     #[ORM\JoinColumn(nullable: false, unique: true)]
     private ?RiotAccount $riotAccount = null;
+
+    /**
+     * Top champions joués par le compte Riot.
+     * Relation inverse de PlayedChampion::$playerStats.
+     *
+     * @var Collection<int, PlayedChampion>
+     */
+    #[ORM\OneToMany(mappedBy: 'playerStats', targetEntity: PlayedChampion::class, cascade: ['persist', 'remove'], orphanRemoval: true)]
+    #[Groups(['player:read'])]
+    private Collection $playedChampions;
+
+    public function __construct()
+    {
+        $this->playedChampions = new ArrayCollection();
+    }
 
     public function getId(): ?int
     {
@@ -122,6 +147,31 @@ class PlayerStats
     public function setRiotAccount(RiotAccount $riotAccount): static
     {
         $this->riotAccount = $riotAccount;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, PlayedChampion>
+     */
+    public function getPlayedChampions(): Collection
+    {
+        return $this->playedChampions;
+    }
+
+    public function addPlayedChampion(PlayedChampion $champion): static
+    {
+        if (!$this->playedChampions->contains($champion)) {
+            $this->playedChampions->add($champion);
+            $champion->setPlayerStats($this);
+        }
+
+        return $this;
+    }
+
+    public function removePlayedChampion(PlayedChampion $champion): static
+    {
+        $this->playedChampions->removeElement($champion);
 
         return $this;
     }

--- a/src/Entity/RiotAccount.php
+++ b/src/Entity/RiotAccount.php
@@ -6,6 +6,7 @@ namespace App\Entity;
 
 use App\Repository\RiotAccountRepository;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
 
 #[ORM\Entity(repositoryClass: RiotAccountRepository::class)]
 class RiotAccount
@@ -13,23 +14,39 @@ class RiotAccount
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
+    #[Groups(['player:read'])]
     private ?int $id = null;
 
     #[ORM\Column(length: 100)]
+    #[Groups(['player:read'])]
     private ?string $summonerName = null;
 
     #[ORM\Column(length: 78, unique: true)]
+    #[Groups(['player:read'])]
     private ?string $puuid = null;
 
     #[ORM\Column(length: 10)]
+    #[Groups(['player:read'])]
     private ?string $region = null;
 
     #[ORM\Column(nullable: true)]
+    #[Groups(['player:read'])]
     private ?\DateTimeImmutable $lastSyncAt = null;
 
-    #[ORM\ManyToOne]
-    #[ORM\JoinColumn(nullable: false)]
+    /**
+     * Un compte Riot appartient à exactement un joueur LoL Scout.
+     */
+    #[ORM\OneToOne(inversedBy: 'riotAccount', targetEntity: Player::class)]
+    #[ORM\JoinColumn(nullable: false, unique: true)]
     private ?Player $player = null;
+
+    /**
+     * Relation inverse vers PlayerStats.
+     * Un compte Riot a au maximum un PlayerStats (créé après une sync).
+     */
+    #[ORM\OneToOne(mappedBy: 'riotAccount', targetEntity: PlayerStats::class)]
+    #[Groups(['player:read'])]
+    private ?PlayerStats $stats = null;
 
     public function getId(): ?int
     {
@@ -92,6 +109,18 @@ class RiotAccount
     public function setPlayer(Player $player): static
     {
         $this->player = $player;
+
+        return $this;
+    }
+
+    public function getStats(): ?PlayerStats
+    {
+        return $this->stats;
+    }
+
+    public function setStats(?PlayerStats $stats): static
+    {
+        $this->stats = $stats;
 
         return $this;
     }


### PR DESCRIPTION
Closes #25

Expose Player -> RiotAccount -> PlayerStats -> PlayedChampion[] dans le groupe `player:read`. Le front peut maintenant afficher rang, winrate, KDA, vision et top 3 champions sans appel API supplementaire.

## Changements
- Relations inverses ajoutees (Player.riotAccount, RiotAccount.stats, PlayerStats.playedChampions)
- RiotAccount.player change de ManyToOne vers OneToOne (UNIQUE player_id en BDD)
- Migration generee : transforme l'index en UNIQUE INDEX

## Verifie en live
GET /api/players renvoie ShadowMid avec Diamond II, 56.30% WR, 142 parties, top 3 champions Ahri/Syndra/Yasuo.