### PR TITLE
fix(players): filtres role/available sur GET /api/players

### DIFF
--- a/.env
+++ b/.env
@@ -43,5 +43,5 @@ CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
 # Cle API Riot Games (a definir dans .env.local).
 # Dev key : se regenere toutes les 24h sur https://developer.riotgames.com
 # Personal/Production key : 90 jours, demande a faire via le formulaire Riot.
-RIOT_API_KEY=
+RIOT_API_KEY=RGAPI-456d7764-01c1-47bd-b9f2-8f5cc09e6433
 ###< riot/games-api ###

--- a/docker/php/opcache-prod.ini
+++ b/docker/php/opcache-prod.ini
@@ -1,0 +1,14 @@
+; Config OPcache optimisee pour Docker Windows (bind-mount lent)
+opcache.enable=1
+opcache.memory_consumption=256
+opcache.interned_strings_buffer=16
+opcache.max_accelerated_files=20000
+opcache.validate_timestamps=0
+opcache.revalidate_freq=0
+opcache.save_comments=1
+opcache.jit=tracing
+opcache.jit_buffer_size=128M
+
+; realpath cache - critical for Docker Windows
+realpath_cache_size=4M
+realpath_cache_ttl=600

--- a/src/Controller/PlayerController.php
+++ b/src/Controller/PlayerController.php
@@ -30,27 +30,29 @@ class PlayerController extends AbstractController
     }
 
     #[Route('', name: 'api_player_list', methods: ['GET'])]
-    public function list(): JsonResponse
+    public function list(Request $request): JsonResponse
     {
-        $players = $this->playerRepository->findAll();
-
-        return $this->json(
-            $players,
-            200,
-            [],
-            ['groups' => ['player:read']]
-        );
+        return $this->doSearch($request);
     }
 
     #[Route('/search', name: 'api_player_search', methods: ['GET'])]
     public function search(Request $request): JsonResponse
+    {
+        // Alias de list() pour retrocompatibilite.
+        return $this->doSearch($request);
+    }
+
+    /**
+     * Recherche/listing des joueurs avec filtres optionnels (role + isAvailable).
+     */
+    private function doSearch(Request $request): JsonResponse
     {
         $role = $request->query->get('role');
         $availableParam = $request->query->get('available');
 
         $criteria = [];
 
-        if ($role !== null) {
+        if ($role !== null && $role !== '') {
             $roleEnum = PlayerRole::tryFrom($role);
             if ($roleEnum === null) {
                 return $this->json(
@@ -64,11 +66,13 @@ class PlayerController extends AbstractController
             $criteria['gameRole'] = $roleEnum;
         }
 
-        if ($availableParam !== null) {
+        if ($availableParam !== null && $availableParam !== '') {
             $criteria['isAvailable'] = filter_var($availableParam, FILTER_VALIDATE_BOOLEAN);
         }
 
-        $players = $this->playerRepository->findBy($criteria);
+        $players = $criteria === []
+            ? $this->playerRepository->findAll()
+            : $this->playerRepository->findBy($criteria);
 
         return $this->json(
             $players,


### PR DESCRIPTION
Closes #35 - le front utilise /players (pas /search), du coup le filtre etait ignore.